### PR TITLE
Return full parsed apple news response to analyze throttling field

### DIFF
--- a/lib/make-request.js
+++ b/lib/make-request.js
@@ -69,7 +69,7 @@ module.exports = function (config) {
           }
 
           if (parsed.data) {
-            return cb(null, res, parsed.data);
+            return cb(null, res, parsed);
           }
 
           if (parsed.errors && Array.isArray(parsed.errors) &&

--- a/lib/make-request.js
+++ b/lib/make-request.js
@@ -69,7 +69,8 @@ module.exports = function (config) {
           }
 
           if (parsed.data) {
-            return cb(null, res, parsed);
+            parsed.data.meta = parsed.meta
+            return cb(null, res, parsed.data);
           }
 
           if (parsed.errors && Array.isArray(parsed.errors) &&


### PR DESCRIPTION
We've been clipping the apple news response at the `data` field, but there's a lot more in there we're losing. To see the contents, look at `Example Code for Updating an Article Without Metadata` and click `Response`

https://developer.apple.com/documentation/apple_news/update_an_article#discussion

More reading: 

This is the article response: https://developer.apple.com/documentation/apple_news/articleresponse

Throttling info:

https://developer.apple.com/documentation/apple_news/throttling