### PR TITLE
Meta is not separate from the response data

### DIFF
--- a/lib/make-request.js
+++ b/lib/make-request.js
@@ -67,7 +67,6 @@ module.exports = function (config) {
         }
 
         if (parsed.data) {
-          parsed.data.meta = parsed.meta;
           return cb(null, res, parsed.data);
         }
 


### PR DESCRIPTION
`meta` is a field _on_ the response `data`. We're losing access to it with this separate assignment.

See example responses:
CREATE: https://developer.apple.com/documentation/apple_news/create_an_article
UPDATE: https://developer.apple.com/documentation/apple_news/update_an_article